### PR TITLE
- Fixed recipes and improved chances

### DIFF
--- a/src/main/java/net/mrqx/slashblade/maidpower/item/SlashBladeMaidBauble.java
+++ b/src/main/java/net/mrqx/slashblade/maidpower/item/SlashBladeMaidBauble.java
@@ -26,10 +26,10 @@ public class SlashBladeMaidBauble implements IMaidBauble {
                 BaubleItemHandler handler = maid.getMaidBauble();
                 RandomSource random = maid.level().getRandom();
                 int exp = event.getEntity().getExperienceReward();
-                if (random.nextDouble() < (double) (exp * exp * exp * exp) / 1000000) {
+                if (random.nextDouble() < Math.min(1.0, exp * 0.01)) {
                     int i = random.nextInt(handler.getSlots());
                     IMaidBauble baubleIn = handler.getBaubleInSlot(i);
-                    if (baubleIn instanceof UnawakenedSoul && random.nextDouble() < (double) (exp * exp * exp * exp) / 1000000) {
+                    if (baubleIn instanceof UnawakenedSoul && random.nextDouble() < Math.min(1.0, exp * 0.01)) {
                         handler.setStackInSlot(i, new ItemStack(MaidPowerItems.SOUL_AWAKENED_LIST.get(random.nextInt(MaidPowerItems.SOUL_AWAKENED_LIST.size())).get()));
                     }
                 }

--- a/src/main/resources/data/true_power_of_maid/recipes/altar/soul_of_power.json
+++ b/src/main/resources/data/true_power_of_maid/recipes/altar/soul_of_power.json
@@ -15,19 +15,19 @@
       "item": "touhou_little_maid:power_point"
     },
     {
-      "item": "true_power_of_maid:proudsoul_crystal"
+      "tag": "true_power_of_maid:soul_awakened"
     },
     {
       "item": "touhou_little_maid:power_point"
     },
     {
-      "item": "true_power_of_maid:proudsoul_crystal"
+      "tag": "true_power_of_maid:soul_awakened"
     },
     {
       "item": "touhou_little_maid:power_point"
     },
     {
-      "item": "true_power_of_maid:proudsoul_crystal"
+      "tag": "true_power_of_maid:soul_awakened"
     }
   ]
 }

--- a/src/main/resources/data/true_power_of_maid/tags/items/soul_awakened.json
+++ b/src/main/resources/data/true_power_of_maid/tags/items/soul_awakened.json
@@ -1,0 +1,16 @@
+{
+  "replace": false,
+  "values": [
+    "true_power_of_maid:soul_of_combo_b",
+    "true_power_of_maid:soul_of_combo_c",
+    "true_power_of_maid:soul_of_rapid_slash",
+    "true_power_of_maid:soul_of_air_combo",
+    "true_power_of_maid:soul_of_mirage_blade",
+    "true_power_of_maid:soul_of_trick",
+    "true_power_of_maid:soul_of_judgement_cut",
+    "true_power_of_maid:soul_of_void_slash",
+    "true_power_of_maid:soul_of_guard",
+    "true_power_of_maid:soul_of_health",
+    "true_power_of_maid:soul_of_exp"
+  ]
+}


### PR DESCRIPTION
- Fixed recipe `soul_of_power.json` that previously failed due to invalid item reference
  - Replaced direct item `true_power_of_maid:proudsoul_crystal` with tag `#true_power_of_maid:soul_awakened`
  - Added new tag file `data/true_power_of_maid/tags/soul_awakened.json` defining all valid soul items
- Updated `SlashBladeMaidBauble.java` logic:
  - Adjusted drop chance for soul_awakened items based on experience

This resolves the KubeJS recipe parsing error and integrates tag-based item selection.
<img width="1703" height="684" alt="javaw_WDtoHIeDSW" src="https://github.com/user-attachments/assets/1e99aa3b-e5e6-4b6b-85de-c2cb41e965bf" />
<img width="1623" height="802" alt="javaw_E3fhtMuTtg" src="https://github.com/user-attachments/assets/bdef5ed2-e8aa-4971-aff1-4d50b19bd81e" />
